### PR TITLE
Fix universal cooldown for rockets

### DIFF
--- a/js/rocketsPage.js
+++ b/js/rocketsPage.js
@@ -49,7 +49,10 @@ export function updateRocketsUI() {
     const callInDelay = effects.streamlinedLaunch ? 0 : weapon.stratCallInTime;
     let baseCallTime = callInDelay + weapon.travelTime;
     if (complexPlotting) baseCallTime *= 1.5;
-    let scd = effects.supportWeaponCooldownMult * weapon.stratCooldown;
+    let scd =
+      weapon.stratCooldown *
+      effects.supportWeaponCooldownMult *
+      effects.universalCooldownMult;
     if (orbitalFluctuations) scd *= 1.25;
 
     let time = baseCallTime;
@@ -84,7 +87,7 @@ export function updateRocketsUI() {
     const shotReload = weapon.reloadTime * payrollMult;
 
     // Base resupply cooldown (modified if Engineering Bay upgrade applied).
-    let baseResupplyCd = 180;
+    let baseResupplyCd = 180 * effects.universalCooldownMult;
     if (effects.sentryEmplacementResupplyCooldownMult < 1) {
       baseResupplyCd *= 0.9;
     }

--- a/js/upgrades.js
+++ b/js/upgrades.js
@@ -80,13 +80,13 @@ export const ALL_UPGRADES = [
     pages: ["stratagems"],
   },
 
-  // Bridge (Stratagems only)
+  // Bridge
   {
     id: "Bridge-1",
     category: "Bridge",
     shortName: "Morale Augmentation",
-    description: "All stratagem cooldowns -5%",
-    pages: ["stratagems"],
+    description: "All stratagem and rocket cooldowns -5%",
+    pages: ["stratagems", "rockets"],
   },
 
   // Engineering Bay

--- a/js/upgrades.js
+++ b/js/upgrades.js
@@ -85,7 +85,7 @@ export const ALL_UPGRADES = [
     id: "Bridge-1",
     category: "Bridge",
     shortName: "Morale Augmentation",
-    description: "All stratagem and rocket cooldowns -5%",
+    description: "All stratagem cooldowns -5%",
     pages: ["stratagems", "rockets"],
   },
 


### PR DESCRIPTION
## Summary
- apply `universalCooldownMult` to expendable rocket cooldowns
- include `universalCooldownMult` when computing backpack resupply cooldown
- show `Morale Augmentation` upgrade on Rockets page

## Testing
- `node --check js/rocketsPage.js`
- `node --check js/upgrades.js`
- `node --check js/main.js`
