### PR TITLE
Update resupply cooldown multiplier usage

### DIFF
--- a/js/rocketsPage.js
+++ b/js/rocketsPage.js
@@ -85,9 +85,7 @@ export function updateRocketsUI() {
 
     // Base resupply cooldown (modified if Engineering Bay upgrade applied).
     let baseResupplyCd = 180;
-    if (effects.sentryEmplacementResupplyCooldownMult < 1) {
-      baseResupplyCd *= 0.9;
-    }
+    baseResupplyCd *= effects.sentryEmplacementResupplyCooldownMult;
     if (orbitalFluctuations) baseResupplyCd *= 1.25;
 
     let resuppliesPerPod = resupplyCount;


### PR DESCRIPTION
## Summary
- directly multiply base resupply cooldown by `sentryEmplacementResupplyCooldownMult`
- remove obsolete conditional

## Testing
- `git status --short`