### PR TITLE
Refactor accordion helpers into utils

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ This repository contains a small web application for calculating Helldivers 2 st
 - `js/upgrades.js`
   - Contains the master list of ship upgrades.
   - Exports utility functions such as `getUpgradeEffects` and `enforceUpgradeProgressions` used across the app.
+- `js/utils/`
+  - Directory for reusable helpers like DOM manipulation utilities.
 
 ## Testing
 - Ensure you have Node (version 20 or later recommended).

--- a/js/main.js
+++ b/js/main.js
@@ -5,6 +5,7 @@ import {
   enforceUpgradeProgressions,
 } from "./upgrades.js";
 import { updateRocketsUI } from "./rocketsPage.js";
+import { openAccordion, closeAccordion } from "./utils/domUtils.js";
 
 /*********************************************************
  * GLOBAL STATE & DOM SELECTORS
@@ -30,17 +31,6 @@ const globalAccordionContent = document.getElementById(
 /*********************************************************
  * ACCORDION OPEN/CLOSE HELPERS
  *********************************************************/
-function openAccordion(headerEl, contentEl) {
-  headerEl.classList.add("active");
-  contentEl.classList.add("open");
-  contentEl.style.maxHeight = contentEl.scrollHeight + "px";
-}
-
-function closeAccordion(headerEl, contentEl) {
-  headerEl.classList.remove("active");
-  contentEl.classList.remove("open");
-  contentEl.style.maxHeight = 0;
-}
 
 // Toggle accordion on header click.
 globalAccordionHeader.addEventListener("click", () => {

--- a/js/utils/domUtils.js
+++ b/js/utils/domUtils.js
@@ -1,0 +1,11 @@
+export function openAccordion(headerEl, contentEl) {
+  headerEl.classList.add("active");
+  contentEl.classList.add("open");
+  contentEl.style.maxHeight = contentEl.scrollHeight + "px";
+}
+
+export function closeAccordion(headerEl, contentEl) {
+  headerEl.classList.remove("active");
+  contentEl.classList.remove("open");
+  contentEl.style.maxHeight = 0;
+}


### PR DESCRIPTION
## Summary
- create `domUtils.js` for accordion helpers
- use these helpers in `main.js`
- document utils directory

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855aa231ac8832da8a9b564c637dbbf