### PR TITLE
Use internal state for UI accordions

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -17,7 +17,7 @@ import {
  *********************************************************/
 export const uiState = {
   shipUpgradesAccordionOpen: false,
-  categoryOpenState: {}
+  categoryOpenState: {},
 };
 // Tab elements and page containers
 const tabStratagems = document.getElementById("tabStratagems");
@@ -239,10 +239,9 @@ function renderTables(stratagems, selectedUpgrades) {
     iconSpan.textContent = "–";
     header.appendChild(iconSpan);
 
-    const isOpen =
-      uiState.categoryOpenState.hasOwnProperty(cat)
-        ? uiState.categoryOpenState[cat]
-        : true;
+    const isOpen = uiState.categoryOpenState.hasOwnProperty(cat)
+      ? uiState.categoryOpenState[cat]
+      : true;
 
     const content = document.createElement("div");
     content.classList.add("category-content");

--- a/js/main.js
+++ b/js/main.js
@@ -15,10 +15,10 @@ import {
 /*********************************************************
  * GLOBAL STATE & DOM SELECTORS
  *********************************************************/
-window.shipUpgradesAccordionOpen = false; // Global flag for accordion state
-// Track open/closed state of each stratagem category accordion
-window.categoryOpenState = {};
-
+export const uiState = {
+  shipUpgradesAccordionOpen: false,
+  categoryOpenState: {}
+};
 // Tab elements and page containers
 const tabStratagems = document.getElementById("tabStratagems");
 const tabRockets = document.getElementById("tabRockets");
@@ -41,10 +41,10 @@ const globalAccordionContent = document.getElementById(
 globalAccordionHeader.addEventListener("click", () => {
   if (globalAccordionContent.classList.contains("open")) {
     closeAccordion(globalAccordionHeader, globalAccordionContent);
-    window.shipUpgradesAccordionOpen = false;
+    uiState.shipUpgradesAccordionOpen = false;
   } else {
     openAccordion(globalAccordionHeader, globalAccordionContent);
-    window.shipUpgradesAccordionOpen = true;
+    uiState.shipUpgradesAccordionOpen = true;
   }
 });
 
@@ -240,8 +240,8 @@ function renderTables(stratagems, selectedUpgrades) {
     header.appendChild(iconSpan);
 
     const isOpen =
-      window.categoryOpenState.hasOwnProperty(cat)
-        ? window.categoryOpenState[cat]
+      uiState.categoryOpenState.hasOwnProperty(cat)
+        ? uiState.categoryOpenState[cat]
         : true;
 
     const content = document.createElement("div");
@@ -338,7 +338,7 @@ function renderTables(stratagems, selectedUpgrades) {
     header.addEventListener("click", () => {
       content.classList.toggle("open");
       const opened = content.classList.contains("open");
-      window.categoryOpenState[cat] = opened;
+      uiState.categoryOpenState[cat] = opened;
       if (opened) {
         iconSpan.textContent = "–";
         content.style.maxHeight = content.scrollHeight + "px";
@@ -412,9 +412,9 @@ tabStratagems.addEventListener("click", () => {
   refreshUpgradesVisibility("stratagems");
 
   // Reset category accordion state so all categories start expanded
-  window.categoryOpenState = {};
+  uiState.categoryOpenState = {};
 
-  if (window.shipUpgradesAccordionOpen) {
+  if (uiState.shipUpgradesAccordionOpen) {
     openAccordion(globalAccordionHeader, globalAccordionContent);
   } else {
     closeAccordion(globalAccordionHeader, globalAccordionContent);
@@ -433,7 +433,7 @@ tabRockets.addEventListener("click", () => {
   enforceProgressionOnAllCheckboxes();
   refreshUpgradesVisibility("rockets");
 
-  if (window.shipUpgradesAccordionOpen) {
+  if (uiState.shipUpgradesAccordionOpen) {
     openAccordion(globalAccordionHeader, globalAccordionContent);
   } else {
     closeAccordion(globalAccordionHeader, globalAccordionContent);
@@ -449,9 +449,9 @@ window.addEventListener("DOMContentLoaded", () => {
   loadSelectedUpgrades();
   enforceProgressionOnAllCheckboxes();
   refreshUpgradesVisibility("stratagems");
-  window.categoryOpenState = {}; // Default all stratagem categories open
+  uiState.categoryOpenState = {}; // Default all stratagem categories open
   closeAccordion(globalAccordionHeader, globalAccordionContent);
-  window.shipUpgradesAccordionOpen = false;
+  uiState.shipUpgradesAccordionOpen = false;
   document.getElementById("searchInput").addEventListener("input", updateUI);
   updateUI();
 });


### PR DESCRIPTION
## Summary
- store accordion open state inside `js/main.js` rather than on `window`
- export `uiState` for potential external access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855f63f2c6c832d94cdd6f90c83beb6